### PR TITLE
The Global Site should not be an available site to Import/Export to

### DIFF
--- a/generators/export/index.js
+++ b/generators/export/index.js
@@ -148,7 +148,10 @@ module.exports = class extends CustomGenerator {
 
     const groups = JSON.parse(response.body);
 
-    return groups.map(group => ({
+    return groups.filter(
+      group => group.descriptiveName != 'Global'
+    )
+    .map(group => ({
       name: group.descriptiveName,
       value: group.groupId
     }));

--- a/generators/import/index.js
+++ b/generators/import/index.js
@@ -160,7 +160,10 @@ module.exports = class extends CustomGenerator {
 
     const groups = JSON.parse(response.body);
 
-    return groups.map(group => ({
+    return groups.filter(
+      group => group.descriptiveName != 'Global'
+    )
+    .map(group => ({
       name: group.descriptiveName,
       value: group.groupId
     }));


### PR DESCRIPTION
**Describe the bug**
Page Fragments are not available for viewing or editing in the global site. And even if we import them to the global site, they are not available globally (other sites). Therefore, we should filter the global site out to prevent user confusion.

**To Reproduce**
Steps to reproduce the behavior:
1. Run npm run-script import or npm run-script export
2. Input valid Portal credentials

**Expected behavior**
Global Site is not an available Liferay Site.

**Screenshots**
<img width="960" alt="conemu64_2019-01-10_17-49-04" src="https://user-images.githubusercontent.com/35234287/51008336-3b43e780-1500-11e9-819d-ea5dfb6ab4c9.png">

**Desktop:**
 - OS: Windows
 - Browser: N/A
 - Version master
