### PR TITLE
Handle server errors in API calls

### DIFF
--- a/generators/import/import.js
+++ b/generators/import/import.js
@@ -1,5 +1,5 @@
 const api = require('../../utils/api');
-const { logData, logNewLine } = require('../../utils/log');
+const { logData, logErrorData, logNewLine } = require('../../utils/log');
 
 /**
  * Fragment types
@@ -117,36 +117,40 @@ async function _importFragment(groupId, existingCollection, fragment) {
     fragment
   );
 
-  if (existingFragment && _fragmentHasChanges(existingFragment, fragment)) {
-    await api.updateFragmentEntry(existingFragment.fragmentEntryId, {
-      status,
-      name,
-      html,
-      css,
-      js,
-      configuration
-    });
-
-    logData('Updated', fragment.metadata.name);
-  } else if (existingFragment) {
-    logData('Up-to-date', fragment.metadata.name);
-  } else {
-    existingFragment = await api.addFragmentEntry(
-      groupId,
-      fragmentCollectionId,
-      fragmentEntryKey,
-      {
+  try {
+    if (existingFragment && _fragmentHasChanges(existingFragment, fragment)) {
+      await api.updateFragmentEntry(existingFragment.fragmentEntryId, {
         status,
         name,
-        type,
         html,
         css,
         js,
         configuration
-      }
-    );
+      });
 
-    logData('Added', fragment.metadata.name);
+      logData('Updated', fragment.metadata.name);
+    } else if (existingFragment) {
+      logData('Up-to-date', fragment.metadata.name);
+    } else {
+      existingFragment = await api.addFragmentEntry(
+        groupId,
+        fragmentCollectionId,
+        fragmentEntryKey,
+        {
+          status,
+          name,
+          type,
+          html,
+          css,
+          js,
+          configuration
+        }
+      );
+
+      logData('Added', fragment.metadata.name);
+    }
+  } catch (error) {
+    logErrorData('Error', fragment.metadata.name, error.toString());
   }
 }
 

--- a/utils/api.js
+++ b/utils/api.js
@@ -69,12 +69,6 @@ const api = {
    * @return {object|string}
    */
   parseResponse(response) {
-    if (response.statusCode >= 400) {
-      throw new Error(
-        `${response.statusCode} ${response.body.substr(0, 100)}...`
-      );
-    }
-
     /** @type {object|string} */
     let responseBody = response.body;
 
@@ -95,6 +89,12 @@ const api = {
       if ('error' in responseBody) {
         throw new Error(responseBody.error);
       }
+    }
+
+    if (response.statusCode >= 400) {
+      throw new Error(
+        `${response.statusCode} ${response.body.substr(0, 100)}...`
+      );
     }
 
     return responseBody;

--- a/utils/log.js
+++ b/utils/log.js
@@ -28,11 +28,25 @@ function logData(message, data) {
  * @param {string} message Message content
  */
 function logError(message) {
-  if (process.env.NODE_ENV !== 'test') {
+  console.log(chalk.red(message));
+}
+
+/**
+ * Logs error data with an optional description
+ * @param {string} message
+ * @param {string} data
+ * @param {string} [description='']
+ */
+function logErrorData(message, data, description) {
+  if (description) {
     console.log('');
   }
 
-  console.log(chalk.red(message));
+  console.log(`${chalk.bold(chalk.red(message))} ${chalk.bold(data)}`);
+
+  if (description) {
+    console.log(description);
+  }
 }
 
 /**
@@ -68,6 +82,7 @@ module.exports = {
   log,
   logData,
   logError,
+  logErrorData,
   logIndent,
   logNewLine,
   logSecondary


### PR DESCRIPTION
Now we log errors when importing fragments to a liferay server
instead of throwing the raw error.

LPS: https://issues.liferay.com/browse/LPS-99953
Fixes #69