### PR TITLE
fix: Use exposed bundler binary instead of npx

### DIFF
--- a/src/utils/project-content/build-project-content.ts
+++ b/src/utils/project-content/build-project-content.ts
@@ -20,8 +20,19 @@ export const buildProjectContent = async (
 
   let builtProjectContent = projectContent;
 
-  if (hasBundlerConfig && projectExports.length) {
-    await execa.command('npx @liferay/npm-bundler', {
+  const bundlerBinaryPath = path.resolve(
+    projectContent.basePath,
+    'node_modules',
+    '.bin',
+    'liferay-npm-bundler'
+  );
+
+  if (
+    hasBundlerConfig &&
+    fs.existsSync(bundlerBinaryPath) &&
+    projectExports.length
+  ) {
+    await execa.command(bundlerBinaryPath, {
       cwd: projectContent.basePath,
     });
 


### PR DESCRIPTION
As this error appeared (https://github.com/liferay/liferay-frontend-projects/issues/217) and discussed with @izaera we found that calling bundler with npx might be problematic in some installations.

I've tried to `require()` the bundler main file but I failed waiting for it to finish (I have no promise or callback to use), so I made a small update that checks if the bundler main file exists inside `node_modules/.bin` and runs it with execa. It looks a little fragile in my opinion, but it should work better than `npx`.