### PR TITLE
Fix: Correctly identify fragment composition files

### DIFF
--- a/src/utils/project-content/get-project-content.ts
+++ b/src/utils/project-content/get-project-content.ts
@@ -177,7 +177,7 @@ function _getCollectionFragmentCompositions(
   collectionDirectory: string
 ): IFragmentComposition[] {
   return glob
-    .sync(path.join(collectionDirectory, '*', 'fragment-composition.json'))
+    .sync(path.join(collectionDirectory, '**', '*', 'fragment-composition.json'))
     .map((compositionJSON: string) => path.resolve(compositionJSON, '..'))
     .filter((directory: string) => {
       try {

--- a/src/utils/project-content/get-project-content.ts
+++ b/src/utils/project-content/get-project-content.ts
@@ -177,7 +177,9 @@ function _getCollectionFragmentCompositions(
   collectionDirectory: string
 ): IFragmentComposition[] {
   return glob
-    .sync(path.join(collectionDirectory, '**', '*', 'fragment-composition.json'))
+    .sync(
+      path.join(collectionDirectory, '**', '*', 'fragment-composition.json')
+    )
     .map((compositionJSON: string) => path.resolve(compositionJSON, '..'))
     .filter((directory: string) => {
       try {


### PR DESCRIPTION
Sorry if I created a PR before creating an issue. The problem is pretty simple, and so is the solution.

Currently Fragments Compositions are not retrieved since they are searched with the following glob:

    <root>/src/<collection>/*/fragment-composition.json

This is not where they are stored since they are grouped inside a `fragment-compositions` folder.

This PR follows the lead of all other `_get*` functions in the `get-project-content.ts` file by using the following glob (please notice the additional `**` in the glob):

    <root>/src/<collection>/**/*/fragment-composition.json