### PR TITLE
Fix bundler resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-liferay-fragments",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Yeoman generator for creating and maintaining Liferay Fragment projects",
   "homepage": "https://www.npmjs.com/package/generator-liferay-fragments",
   "author": {

--- a/src/app/__tests__/__snapshots__/app-generator.spec.js.snap
+++ b/src/app/__tests__/__snapshots__/app-generator.spec.js.snap
@@ -80,7 +80,7 @@ Object {
   },
 
   \\"devDependencies\\": {
-    \\"generator-liferay-fragments\\": \\"2.1.0\\"
+    \\"generator-liferay-fragments\\": \\"2.1.1\\"
   }
 }
 ",
@@ -201,7 +201,7 @@ Object {
   },
 
   \\"devDependencies\\": {
-    \\"generator-liferay-fragments\\": \\"2.1.0\\"
+    \\"generator-liferay-fragments\\": \\"2.1.1\\"
   }
 }
 ",
@@ -376,7 +376,7 @@ Object {
   },
 
   \\"devDependencies\\": {
-    \\"generator-liferay-fragments\\": \\"2.1.0\\"
+    \\"generator-liferay-fragments\\": \\"2.1.1\\"
   }
 }
 ",

--- a/src/utils/project-content/build-project-content.ts
+++ b/src/utils/project-content/build-project-content.ts
@@ -9,10 +9,6 @@ import getProjectContent from './get-project-content';
 import { getProjectExports } from './get-project-exports';
 import writeProjectContent from './write-project-content';
 
-const nodeModulesBinPath = path.normalize(
-  path.resolve(__dirname, '../../../node_modules/.bin')
-);
-
 export const buildProjectContent = async (
   projectContent: IProject
 ): Promise<IProject> => {
@@ -29,7 +25,10 @@ async function applySASS(
   const tmpDir = createTemporaryDirectory();
   await writeProjectContent(tmpDir.name, projectContent);
   const builtProjectContent = getProjectContent(tmpDir.name);
-  const sassBinaryPath = path.resolve(nodeModulesBinPath, 'sass');
+
+  const sassBinaryPath = require
+    .resolve('sass')
+    .replace('sass.default.dart.js', 'sass.js');
 
   for (const collection of builtProjectContent.collections) {
     for (const fragment of collection.fragments) {
@@ -125,10 +124,12 @@ async function applyNPMBundler(projectContent: IProject): Promise<IProject> {
 
   let builtProjectContent = projectContent;
 
-  const bundlerBinaryPath = path.resolve(
-    nodeModulesBinPath,
-    'liferay-npm-bundler'
-  );
+  const bundlerBinaryPath = require
+    .resolve('@liferay/npm-bundler')
+    .replace(
+      path.join('lib', 'index.js'),
+      path.join('bin', 'liferay-npm-bundler.js')
+    );
 
   if (
     hasBundlerConfig &&


### PR DESCRIPTION
Hey there!

I found an issue while using the toolkit. In some projects, the npm bundler path is not resolved correctly when using NPM in a new project. NPM tries to flatten the dependency tree, and it does not create symlinks un dependencies binaries unless necessary.

I checked the NPM docs, and apparently using `require.resolve` is the way to go when you need to get the directory of a dependency, which is our case.